### PR TITLE
Fix post-attach src attribute assignment

### DIFF
--- a/include-fragment-element.js
+++ b/include-fragment-element.js
@@ -57,9 +57,14 @@
   });
 
   IncludeFragmentPrototype.attributeChangedCallback = function(attrName) {
-    // Reload data load cache
     if (attrName === 'src') {
-      getData(this);
+      // Reload data load cache.
+      var data = getData(this);
+
+      // Source changed after attached so replace element.
+      if (this.parentNode) {
+        handleData(this, data);
+      }
     }
   };
 

--- a/include-fragment-element.js
+++ b/include-fragment-element.js
@@ -80,6 +80,10 @@
     }
   };
 
+  IncludeFragmentPrototype.detachedCallback = function() {
+    this._attached = false;
+  }
+
   IncludeFragmentPrototype.load = function(url) {
     var self = this;
 

--- a/include-fragment-element.js
+++ b/include-fragment-element.js
@@ -69,7 +69,9 @@
   };
 
   IncludeFragmentPrototype.attachedCallback = function() {
-    handleData(this, getData(this));
+    if (this.src) {
+      handleData(this, getData(this));
+    }
   };
 
   IncludeFragmentPrototype.load = function(url) {

--- a/include-fragment-element.js
+++ b/include-fragment-element.js
@@ -62,7 +62,7 @@
       var data = getData(this);
 
       // Source changed after attached so replace element.
-      if (this.parentNode) {
+      if (this._attached) {
         handleData(this, data);
       }
     }
@@ -74,6 +74,7 @@
   };
 
   IncludeFragmentPrototype.attachedCallback = function() {
+    this._attached = true;
     if (this.src) {
       handleData(this, getData(this));
     }

--- a/test/test.js
+++ b/test/test.js
@@ -187,3 +187,19 @@ asyncTest('adds is-error class on mising Content-Type', 1, function() {
     start();
   });
 });
+
+asyncTest('replaces element when src attribute is changed', 2, function() {
+  var div = document.createElement('div');
+  div.innerHTML = '<include-fragment>loading</include-fragment>';
+  document.getElementById('qunit-fixture').appendChild(div);
+
+  div.firstChild.addEventListener('load', function() {
+    equal(document.querySelector('include-fragment'), null);
+    equal(document.querySelector('#replaced').textContent, 'hello');
+    start();
+  });
+
+  setTimeout(function() {
+    div.firstChild.src = '/hello';
+  }, 10);
+});


### PR DESCRIPTION
This branch allows the `src` attribute to be assigned after the `include-fragment` element has been attached to the page.

The page is loaded with the following markup:

```html
<include-fragment src="">
  Loading...
</include-fragment>
```

JavaScript later assigns the `src` attribute so that the replacement content is then fetched and swapped into the page.

```js
document.querySelector('include-fragment').src = '/test'
```

The current behavior considers the lack of a `src` value to be an unrecoverable failure. Setting `src` after the element has been attached *does* fetch the new content, but it's never inserted into the page.

/cc @josh