### PR TITLE
Suppress error message in web console during pre-load.

### DIFF
--- a/include-fragment-element.js
+++ b/include-fragment-element.js
@@ -84,7 +84,7 @@
 
   IncludeFragmentPrototype.detachedCallback = function() {
     this._attached = false;
-  }
+  };
 
   IncludeFragmentPrototype.load = function(url) {
     var self = this;

--- a/include-fragment-element.js
+++ b/include-fragment-element.js
@@ -70,7 +70,9 @@
 
   IncludeFragmentPrototype.createdCallback = function() {
     // Preload data cache
-    getData(this);
+    getData(this)['catch'](function() {
+      // Ignore `src missing` error on pre-load.
+    });
   };
 
   IncludeFragmentPrototype.attachedCallback = function() {


### PR DESCRIPTION
Following up to #18, this suppresses the "uncaught missing src" promise message in the Chrome web inspector on page load. It just needs some `catch` handler registered to make Chrome happy.

![6be93f54-c813-11e4-97b2-0c35038312da](https://cloud.githubusercontent.com/assets/122102/6623083/649521e4-c8a6-11e4-9f0f-f772022fe210.png)

An alternative would be to avoid loading the `data` promise in the `createdCallback` if `this.src` is null. That would result in `element.data` returning null immediately after creating the element via JS.

/cc @josh