### PR TITLE
Adding include-fragment-element.css to include with package

### DIFF
--- a/include-fragment-element.css
+++ b/include-fragment-element.css
@@ -1,5 +1,4 @@
-include-fragment,
-poll-include-fragment {
+include-fragment {
   // Normalize as a block element across all browsers
   display: block;
 }

--- a/include-fragment-element.css
+++ b/include-fragment-element.css
@@ -1,0 +1,5 @@
+include-fragment,
+poll-include-fragment {
+  // Normalize as a block element across all browsers
+  display: block;
+}

--- a/include-fragment-element.css
+++ b/include-fragment-element.css
@@ -1,4 +1,4 @@
 include-fragment {
-  // Normalize as a block element across all browsers
+  /* Normalize as a block element across all browsers */
   display: block;
 }


### PR DESCRIPTION
I wanted to include the `include-fragment-element.css` with this package. The css exists to normalize the custom html elements.

Then in app we're going to include this css with

```scss
@import "include-fragment-element/include-fragment-element";
```

to: @github/js 
cc: @github/design-systems 