### PR TITLE
Add LICENSE to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "include-fragment-element",
   "main": "include-fragment-element.js",
+  "license": "LICENSE",
   "devDependencies": {
     "classlist": "2014.7.23",
     "CustomElements": "0.2.4",


### PR DESCRIPTION
I ran into an issue where my [Dependency CI](https://dependencyci.com/github/education/classroom/builds/77) was failing because npm couldn't find the license.

This adds the `LICENSE` to the `bower.json` so that npm can pick it up.

I'm pretty sure this solves the issue but I'm not 100% sure ¯\_(ツ)_/¯