### PR TITLE
Guard against missing parent when replacing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "classlist": "2014.7.23",
     "CustomElements": "0.2.4",
-    "es5-basic-shim": "1.0.6",
+    "es5-shim": "4.5.9",
     "es6-promise": "1.0.0",
     "MutationObserver": "0.2.0",
     "qunit": "1.14.0",

--- a/include-fragment-element.js
+++ b/include-fragment-element.js
@@ -13,8 +13,11 @@
 
   function handleData(el, data) {
     return data.then(function(html) {
-      el.insertAdjacentHTML('afterend', html);
-      el.parentNode.removeChild(el);
+      var parentNode = el.parentNode;
+      if (parentNode) {
+        el.insertAdjacentHTML('afterend', html);
+        parentNode.removeChild(el);
+      }
     }, function() {
       el.classList.add('is-error');
     });

--- a/test/test.html
+++ b/test/test.html
@@ -9,7 +9,7 @@
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
 
-  <script src="../bower_components/es5-basic-shim/src/shim.js"></script>
+  <script src="../bower_components/es5-shim/es5-shim.js"></script>
   <script src="../bower_components/es6-promise/promise.js"></script>
   <script src="../bower_components/classlist/classList.js"></script>
   <script src="../bower_components/WeakMap/WeakMap.js"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -206,7 +206,7 @@ asyncTest('adds is-error class on 500 status', 1, function() {
   div.innerHTML = '<include-fragment src="/boom">loading</include-fragment>';
   document.getElementById('qunit-fixture').appendChild(div);
 
-  div.firstChild.addEventListener('error', function(event) {
+  div.firstChild.addEventListener('error', function() {
     ok(document.querySelector('include-fragment').classList.contains('is-error'));
     start();
   });
@@ -217,7 +217,7 @@ asyncTest('adds is-error class on mising Content-Type', 1, function() {
   div.innerHTML = '<include-fragment src="/blank-type">loading</include-fragment>';
   document.getElementById('qunit-fixture').appendChild(div);
 
-  div.firstChild.addEventListener('error', function(event) {
+  div.firstChild.addEventListener('error', function() {
     ok(document.querySelector('include-fragment').classList.contains('is-error'));
     start();
   });

--- a/test/test.js
+++ b/test/test.js
@@ -176,6 +176,30 @@ asyncTest('replaces element on 200 status', 2, function() {
   });
 });
 
+asyncTest('does not replace element if it has no parent', 2, function() {
+  var div = document.createElement('div');
+  div.innerHTML = '<include-fragment src="/hello">loading</include-fragment>';
+  document.getElementById('qunit-fixture').appendChild(div);
+
+  var fragment = div.firstChild;
+  fragment.remove();
+
+  window.addEventListener('unhandledrejection', function() {
+    ok(false);
+  });
+
+  fragment.addEventListener('load', function() {
+    equal(document.querySelector('#replaced'), null);
+    start();
+
+    div.appendChild(fragment);
+
+    setTimeout(function() {
+      equal(document.querySelector('#replaced').textContent, 'hello');
+    }, 10);
+  });
+});
+
 asyncTest('replaces with several new elements on 200 status', 3, function() {
   var div = document.createElement('div');
   div.innerHTML = '<include-fragment src="/one-two">loading</include-fragment>';


### PR DESCRIPTION
Currently if the `data` promise resolves while the element does not have a parent, the following error will be logged:

```
Uncaught (in promise) DOMException: Failed to execute 'insertAdjacentHTML' on 'Element': The element has no parent.
    at http://localhost:5001/include-fragment-element.js:16:10
    at <anonymous>
```

This pull request guards for this case and also makes a few small tweaks to get the tests running again.

I was getting the following error on master from bower because of a missing `es5-basic-shim`:

```
bower es5-basic-shim#1.0.6     ECMDERR Failed to execute "git ls-remote --tags --heads https://github.com/radubrehar/es5-basic-shim.git", exit code of #128
```

Also removes a few linter errors that exist on master.