### PR TITLE
Fix custom elements added via insertAdjacentHTML never were upgraded

### DIFF
--- a/include-fragment-element.js
+++ b/include-fragment-element.js
@@ -17,6 +17,10 @@ function handleData(el, data) {
       if (parentNode) {
         el.insertAdjacentHTML('afterend', html)
         parentNode.removeChild(el)
+
+        // Hack to get custom elements in html upgraded
+        // https://github.com/webcomponents/custom-elements/issues/104
+        parentNode.innerHTML = parentNode.innerHTML
       }
     },
     function() {


### PR DESCRIPTION
This is a custom elements polyfill issue. This fix is not ideal, but 🤷🏻. An alternative is to patch `insertAdjacentHTML` ourselves.

Relevant issues: 
- https://github.com/webcomponents/custom-elements/issues/104
- https://github.com/webcomponents/custom-elements/issues/71

