### PR TITLE
Explicitly set a static name property

### DIFF
--- a/include-fragment-element.js
+++ b/include-fragment-element.js
@@ -50,6 +50,10 @@ export default class IncludeFragmentElement extends HTMLElement {
     return ['src']
   }
 
+  static get name() {
+    return 'IncludeFragmentElement'
+  }
+
   get src() {
     const src = this.getAttribute('src')
     if (src) {

--- a/include-fragment-element.js.flow
+++ b/include-fragment-element.js.flow
@@ -2,6 +2,7 @@
 
 declare class IncludeFragmentElement extends HTMLElement {
   get data(): Promise<string>;
+  static get name(): string;
   get src(): string;
   set src(url: string): void;
   fetch(request: Request): Promise<Response>;


### PR DESCRIPTION
Currently if you minimize your code with `IncludeFragmentElement` included it might end up in your bundle as a function with a single character name.

This PR makes sure that `IncludeFragmentElement.name` will always return `include-element` so that our error reporting tools will show the correct element name.