### PR TITLE
use `ensure-name-for-custom-elements` babel plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,14 @@
 {
   "plugins": [
     "transform-custom-element-classes",
+    "ensure-name-for-custom-elements"
   ],
   "presets": [["es2015", { "modules": false }]],
   "env": {
     "umd": {
       "plugins": [
         "transform-custom-element-classes",
+        "ensure-name-for-custom-elements",
         "transform-es2015-modules-umd"
       ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -627,6 +627,12 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-ensure-name-for-custom-elements": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ensure-name-for-custom-elements/-/babel-plugin-ensure-name-for-custom-elements-0.0.2.tgz",
+      "integrity": "sha512-tvbWsrDSk26eufkv79Ukqd4hgPo4SaJA4ax4GffL0eZcbGSfN2mTiiviI+gPQnskq502t6JS28wFtqcmdxrhjQ==",
+      "dev": true
+    },
     "babel-plugin-transform-custom-element-classes": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-custom-element-classes/-/babel-plugin-transform-custom-element-classes-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-plugin-ensure-name-for-custom-elements": "0.0.2",
     "babel-plugin-transform-custom-element-classes": "^0.1.0",
     "babel-preset-es2015": "^6.24.1",
     "chai": "^4.1.2",


### PR DESCRIPTION
Alternative to #38. The babel plugin makes sure there is a static getter `name` on all custom elements so that when you minify them you can still get the name of the element.

Ref: https://github.com/github/babel-plugin-ensure-name-for-custom-elements and https://github.com/github/eslint-plugin-github/pull/52