### PR TITLE
use `Event` constructor instead of `event.initEvent`

### DIFF
--- a/include-fragment-element.js
+++ b/include-fragment-element.js
@@ -4,9 +4,7 @@ const privateData = new WeakMap()
 
 function fire(name, target) {
   setTimeout(function() {
-    const event = target.ownerDocument.createEvent('Event')
-    event.initEvent(name, false, false)
-    target.dispatchEvent(event)
+    target.dispatchEvent(new Event(name))
   }, 0)
 }
 


### PR DESCRIPTION
`Document.createEvent` and `Event.initEvent` are deprecated. This patch replaces those with a simple `new Event(name)` construction instead.

I think creating the event from `target.ownerDocument` doesn't matter? I couldn't find any reference to it on MDN or when googling it. Please let me know if you think it matters and in which way and I can test for it 🔍 

### 📚 Reading

- [`Document.createEvent()` - MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/createEvent)
- [`Event.initEvent()` - MDN](https://developer.mozilla.org/en-US/docs/Web/API/Event/initEvent)
- [`Event()` - MDN](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event)