### PR TITLE
types(TS): add window declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,3 +3,9 @@ export default class IncludeFragmentElement extends HTMLElement {
   src: string;
   fetch(request: Request): Promise<Response>;
 }
+
+declare global {
+  interface Window {
+    IncludeFragmentElement: IncludeFragmentElement
+  }
+}


### PR DESCRIPTION
The TypeScript definition is incomplete as it doesn't properly reflect this code:

https://github.com/github/include-fragment-element/blob/213d197be7a34d01de29e28cfbd25ca28e8b5522/include-fragment-element.js#L143-L146

This PR adds the declaration of `IncludeFragmentElement` to the global window object, as that mutation is happening within the code and so should be reflected in the types.

This type is already in the FlowType code, somewhat implicitly by having `declare class` _outside_ of `declare module`:

https://github.com/github/include-fragment-element/blob/213d197be7a34d01de29e28cfbd25ca28e8b5522/include-fragment-element.js.flow#L3