### PR TITLE
types(ts): fix window declaration type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,6 @@ export default class IncludeFragmentElement extends HTMLElement {
 
 declare global {
   interface Window {
-    IncludeFragmentElement: IncludeFragmentElement
+    IncludeFragmentElement: typeof IncludeFragmentElement
   }
 }


### PR DESCRIPTION
This _fixes_ the window declaration type to be `typeof ` rather than the literal type, which is the correct way to declare this type.