### PR TITLE
Include module in Flow declaration

### DIFF
--- a/include-fragment-element.js.flow
+++ b/include-fragment-element.js.flow
@@ -1,12 +1,10 @@
 /* @flow strict */
 
-declare class IncludeFragmentElement extends HTMLElement {
-  get data(): Promise<string>;
-  get src(): string;
-  set src(url: string): void;
-  fetch(request: Request): Promise<Response>;
-}
-
-declare module 'include-fragment-element' {
-  declare export default typeof IncludeFragmentElement
+declare module '@github/include-fragment-element' {
+  declare export default class IncludeFragmentElement extends HTMLElement {
+    get data(): Promise<string>;
+    get src(): string;
+    set src(url: string): void;
+    fetch(request: Request): Promise<Response>;
+  }
 }


### PR DESCRIPTION
Fixes an error importing the class.

```js
import IncludeFragmentElement from '@github/include-fragment-element'
```
> Error: Importing from an untyped module makes it `any` and is not safe!