### PR TITLE
Also run tests in firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3910,6 +3910,12 @@
       "dev": true,
       "optional": true
     },
+    "is-wsl": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+      "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+      "dev": true
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4189,6 +4195,15 @@
         "which": "^1.2.1"
       }
     },
+    "karma-firefox-launcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.2.0.tgz",
+      "integrity": "sha512-j9Zp8M8+VLq1nI/5xZGfzeaEPtGQ/vk3G+Y8vpmFWLvKLNZ2TDjD6cu2dUu7lDbu1HXNgatsAX4jgCZTkR9qhQ==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "^2.1.0"
+      }
+    },
     "karma-mocha": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-1.3.0.tgz",
@@ -4426,7 +4441,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -5261,7 +5276,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "optional": true,
@@ -5496,7 +5511,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "karma": "^4.3.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",
+    "karma-firefox-launcher": "^1.2.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "mocha": "^6.2.1"

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
     client: {mocha: {ui: 'tdd'}},
     colors: true,
     logLevel: config.LOG_INFO,
-    browsers: ['ChromeHeadless'],
+    browsers: ['ChromeHeadless', 'FirefoxHeadless'],
     autoWatch: false,
     singleRun: true,
     concurrency: Infinity


### PR DESCRIPTION
We can add https://github.com/koddsson/karma-edgium-launcher to the list when https://github.com/actions/virtual-environments/issues/99 is resolved.

(We could run https://github.com/karma-runner/karma-edge-launcher on Windows machines but I'd rather wait for Edgium on all platforms)

Motivated by https://github.com/github/include-fragment-element/pull/52#discussion_r346848398.