### PR TITLE
Fix checking of accept header

### DIFF
--- a/include-fragment-element.js
+++ b/include-fragment-element.js
@@ -123,7 +123,7 @@ export default class IncludeFragmentElement extends HTMLElement {
           throw new Error(`Failed to load resource: the server responded with a status of ${response.status}`)
         }
         const ct = response.headers.get('Content-Type')
-        if (!isWildcard(this.accept) && (!ct || !ct.match(this.accept ? this.accept : /^text\/html/))) {
+        if (!isWildcard(this.accept) && (!ct || !ct.includes(this.accept ? this.accept : 'text/html'))) {
           throw new Error(`Failed to load resource: expected ${this.accept || 'text/html'} but was ${ct}`)
         }
         return response

--- a/test/test.js
+++ b/test/test.js
@@ -41,11 +41,11 @@ const responses = {
     })
   },
   '/fragment': function(request) {
-    if (request.headers.get('Accept') === 'text/html; fragment') {
+    if (request.headers.get('Accept') === 'text/fragment+html') {
       return new Response('<div id="fragment">fragment</div>', {
         status: 200,
         headers: {
-          'Content-Type': 'text/html; fragment'
+          'Content-Type': 'text/fragment+html'
         }
       })
     } else {
@@ -197,7 +197,7 @@ suite('include-fragment-element', function() {
 
   test('throws on non-matching Content-Type', function() {
     const el = document.createElement('include-fragment')
-    el.setAttribute('accept', 'text/html; fragment')
+    el.setAttribute('accept', 'text/fragment+html')
     el.setAttribute('src', '/hello')
 
     return el.data.then(
@@ -205,7 +205,7 @@ suite('include-fragment-element', function() {
         assert.ok(false)
       },
       error => {
-        assert.match(error, /expected text\/html; fragment but was text\/html; charset=utf-8/)
+        assert.match(error, /expected text\/fragment\+html but was text\/html; charset=utf-8/)
       }
     )
   })
@@ -309,7 +309,7 @@ suite('include-fragment-element', function() {
 
   test('replaces with response with the right accept header', function() {
     const div = document.createElement('div')
-    div.innerHTML = '<include-fragment src="/fragment" accept="text/html; fragment">loading</include-fragment>'
+    div.innerHTML = '<include-fragment src="/fragment" accept="text/fragment+html">loading</include-fragment>'
     document.body.appendChild(div)
 
     return when(div.firstChild, 'load').then(() => {


### PR DESCRIPTION
I might be doing regex wrong but as far as I can tell, when we add a `+` to the accept header everything goes to hell.

I couldn't get anything to match correctly:

```
> 'text/fragment+html'.match('text/fragment+html')
null
> 'text/fragment\+html'.match('text/fragment+html')
null
> 'text/fragment\+html'.match('text/fragment\+html')
null
> 'text/fragment\+html'.match('text/fragment+html')
null
> 'text/fragment+html'.match('text/fragment\+html')
null
```

But using a simple string includes works fine 😄 

```
> 'text/fragment+html'.includes('text/fragment+html')
true
```

We use a `.includes(..)`  here since the content type might have additional info such as charset. Something like `text/fragment+html; charset=utf8`.
