### PR TITLE
Add custom events to provide fragment access

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Request lifecycle events are dispatched on the `<include-fragment>` element.
 - `load` - The request completed successfully.
 - `error` - The request failed.
 - `loadend` - The request has completed.
+- `include-fragment-replace` (cancelable) - The success response has been parsed. It comes with `event.detail.fragment` that will replace the current element.
+- `include-fragment-replaced` - The element has been replaced by the fragment.
 
 ```js
 const loader = document.querySelector('include-fragment')

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,13 @@ async function handleData(el: IncludeFragmentElement) {
   // eslint-disable-next-line github/no-then
   return getData(el).then(
     function (html: string) {
-      const parentNode = el.parentNode
-      if (parentNode) {
-        el.insertAdjacentHTML('afterend', html)
-        parentNode.removeChild(el)
-      }
+      const template = document.createElement('template')
+      template.innerHTML = html
+      const fragment = document.importNode(template.content, true)
+      const canceled = !el.dispatchEvent(new CustomEvent('include-fragment-replace', {cancelable: true, detail: {fragment}}))
+      if (canceled) return
+      el.replaceWith(fragment)
+      el.dispatchEvent(new CustomEvent('include-fragment-replaced'))
     },
     function () {
       el.classList.add('is-error')

--- a/test/test.js
+++ b/test/test.js
@@ -371,4 +371,53 @@ suite('include-fragment-element', function() {
       assert.equal(document.querySelector('#replaced').textContent, 'hello')
     })
   })
+
+  test.only('fires replaced event', function() {
+    const elem = document.createElement('include-fragment')
+    document.body.appendChild(elem)
+
+    setTimeout(function() {
+      elem.src = '/hello'
+    }, 10)
+
+    return when(elem, 'include-fragment-replaced').then(() => {
+      assert.equal(document.querySelector('include-fragment'), null)
+      assert.equal(document.querySelector('#replaced').textContent, 'hello')
+    })
+  })
+
+  test.only('fires events for include-fragment node replacement operations for fragment manipulation', function() {
+    const elem = document.createElement('include-fragment')
+    document.body.appendChild(elem)
+
+    setTimeout(function() {
+      elem.src = '/hello'
+    }, 10)
+
+    elem.addEventListener('include-fragment-replace', event => {
+      event.detail.fragment.querySelector('*').textContent = 'hey'
+    })
+
+    return when(elem, 'include-fragment-replaced').then(() => {
+      assert.equal(document.querySelector('include-fragment'), null)
+      assert.equal(document.querySelector('#replaced').textContent, 'hey')
+    })
+  })
+
+  test.only('does not replace node if event was canceled ', function() {
+    const elem = document.createElement('include-fragment')
+    document.body.appendChild(elem)
+
+    setTimeout(function() {
+      elem.src = '/hello'
+    }, 10)
+
+    elem.addEventListener('include-fragment-replace', event => {
+      event.preventDefault()
+    })
+
+    return when(elem, 'load').then(() => {
+      assert(document.querySelector('include-fragment'), 'Node should not be replaced')
+    })
+  })
 })


### PR DESCRIPTION
- Replace `el.insertAdjacentHTML` + `parent.removeChild(el)` with `el.replaceWith`.
- Add custom events to provide fragment access

This is to support our use cases for in-place refreshing of the same fragment. In those cases, the source will return another instance of `include-fragment` to be loaded on demand. We use these events to:

1. Obtain a reference of a focus target so we can restore focus after node replacement
2. Manipulate the fragment to restore element expand states prior to node replacement
3. Check if user is currently interacting with the element to prevent disruptive updates
