### PR TITLE
Feat add loading lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ On page load, the `include-fragment` element fetches the URL, the response is pa
 
 The server must respond with an HTML fragment to replace the `include-fragment` element. It should not contain _another_ `include-fragment` element or the server will be polled in an infinite loop.
 
+### Other Attributes
+
+#### accept
+
+This attribute tells `<include-fragment/>` what to send as the `Accept` header, as part of the fetch request. If omitted, or if set to an empty value, the default behaviour will be `text/html`. It is important that the server responds with HTML, but you may wish to change the accept header to help negotiate the right content with the server.
+
+#### loading
+
+This indicates _when_ the contents should be fetched:
+
+ - `eager`: Fetches and load the content immediately, regardless of whether or not the `<include-fragment/>` is currently within the visible viewport (this is the default value).
+ - `lazy`: Defers fetching and loading the content until the `<include-fragment/>` tag reaches a calculated distance from the viewport. The intent is to avoid the network and storage bandwidth needed to handle the content until it's reasonably certain that it will be needed.
+
+The 
+
 ### Errors
 
 If the URL fails to load, the `include-fragment` element is left in the page and tagged with an `is-error` CSS class that can be used for styling.

--- a/examples/index.html
+++ b/examples/index.html
@@ -8,5 +8,9 @@
   <include-fragment src="./pull.html">Loading</include-fragment>
   <!-- <script type="module" src="../dist/index.js"></script> -->
   <script type="module" src="https://unpkg.com/@github/include-fragment-element@latest?module"></script>
+  <details>
+    <summary>Click to unfold a lazy include-fragment</summary>
+    <include-fragment src="./pull.html" loading="lazy">Loading</include-fragment>
+  </details>
 </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ export default class IncludeFragmentElement extends HTMLElement {
   attributeChangedCallback(attribute: string, oldVal:string|null): void {
     if (attribute === 'src') {
       // Source changed after attached so replace element.
-      if (this.isConnected) {
+      if (this.isConnected && this.loading === 'eager') {
         handleData(this)
       }
     } else if (attribute === 'loading') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,10 @@ const observer = new IntersectionObserver(entries => {
     }
   }
 }, {
+  // Currently the threshold is set to 256px from the bottom of the viewport
+  // with a threshold of 0.1. This means the element will not load until about
+  // 2 keyboard-down-arrow presses away from being visible in the viewport,
+  // giving us some time to fetch it before the contents are made visible
   rootMargin: '0px 0px 256px 0px',
   threshold: 0.01
 })

--- a/test/test.js
+++ b/test/test.js
@@ -466,6 +466,21 @@ suite('include-fragment-element', function() {
     ])
   })
 
+  test('loading=lazy does not load when src is changed', function() {
+    const div = document.createElement('div')
+    div.innerHTML = '<include-fragment loading="lazy" src="">loading</include-fragment>'
+    div.hidden = true
+    document.body.appendChild(div)
+    div.firstChild.src = '/hello'
+    return Promise.race([
+      when(div.firstChild, 'load').then(() => {
+        throw new Error('<include-fragment loading=lazy> loaded too early')
+      }),
+      new Promise(resolve => setTimeout(resolve, 100))
+    ])
+  })
+
+
   test('loading=lazy loads as soon as element visible on page', function() {
     const div = document.createElement('div')
     div.innerHTML = '<include-fragment loading="lazy" src="/hello">loading</include-fragment>'


### PR DESCRIPTION
This adds a new attribute `loading`, which can be either `lazy` or `eager` (the default value). This follows similar semantics & behaviour to [the loading attribute of `<img>` tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Img#attr-loading). 

If the `loading` value is set to _anything but_ `lazy` then the existing behaviour applies - therefore this is not a breaking change.

If the `loading` value is set to `lazy` then the fetch will not trigger as part of the `connectedCallback`. Instead the element is added to a global `IntersectionObserver`, and only when the element is close to being visible in the viewport will the contents be fetched and the element replaced.

Currently the threshold is set to `256px` from the bottom of the viewport with a threshold of `0.1`. These seem like relatively sensible values, where the element will still be off screen but will be (from my testing) about 2 keyboard-down-arrow presses away from being visible in the viewport, giving us some time to fetch it before the contents are made visible.

Using the intersection observer also allows us to defer loading until any parent elements that are hidden become visible. IntersectionObserver tracks the visibility status of the element, so it won't be intersecting if it is say, for example, inside a unopened `<details>` element. This means `<include-fragment loading="lazy">` elements can be hidden behind dialogs or menus and their contents will be loaded only when those elements open. Of course early loading can occur by calling `.load` on the element.