### PR TITLE
fix: guarantee order of load events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,12 +163,18 @@ export default class IncludeFragmentElement extends HTMLElement {
         return response.text()
       })
       .then(data => {
+        // Dispatch `load` and `loadend` async to allow
+        // the `load()` promise to resolve _before_ these
+        // events are fired.
         task().then(() => {
           this.dispatchEvent(new Event('load'))
           this.dispatchEvent(new Event('loadend'))
         })
         return data
       }, error => {
+        // Dispatch `error` and `loadend` async to allow
+        // the `load()` promise to resolve _before_ these
+        // events are fired.
         task().then(() => {
           this.dispatchEvent(new Event('error'))
           this.dispatchEvent(new Event('loadend'))

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,13 +21,9 @@ const observer = new IntersectionObserver(entries => {
 })
 
 
-function fire(name: string, target: Element): Promise<void> {
-  return new Promise(resolve => {
-    setTimeout(function () {
-      target.dispatchEvent(new Event(name))
-      resolve()
-    }, 0)
-  })
+// Functional stand in for the W3 spec "queue a task" paradigm
+function task(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0))
 }
 
 async function handleData(el: IncludeFragmentElement) {
@@ -152,8 +148,11 @@ export default class IncludeFragmentElement extends HTMLElement {
   load(): Promise<string> {
     observer.unobserve(this)
     return Promise.resolve()
-      .then(() => fire('loadstart', this))
-      .then(() => this.fetch(this.request()))
+      .then(task)
+      .then(() => {
+        this.dispatchEvent(new Event('loadstart'))
+        return this.fetch(this.request())
+      })
       .then(response => {
         if (response.status !== 200) {
           throw new Error(`Failed to load resource: the server responded with a status of ${response.status}`)
@@ -165,10 +164,16 @@ export default class IncludeFragmentElement extends HTMLElement {
         return response.text()
       })
       .then(data => {
-        fire('load', this).then(() => fire('loadend', this))
+        task().then(() => {
+          this.dispatchEvent(new Event('load'))
+          this.dispatchEvent(new Event('loadend'))
+        })
         return data
       }, error => {
-        fire('error', this).then(() => fire('loadend', this))
+        task().then(() => {
+          this.dispatchEvent(new Event('error'))
+          this.dispatchEvent(new Event('loadend'))
+        })
         throw error
       })
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,8 +147,7 @@ export default class IncludeFragmentElement extends HTMLElement {
 
   load(): Promise<string> {
     observer.unobserve(this)
-    return Promise.resolve()
-      .then(task)
+    return task()
       .then(() => {
         this.dispatchEvent(new Event('loadstart'))
         return this.fetch(this.request())

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ export default class IncludeFragmentElement extends HTMLElement {
       })
       .then(data => {
         fire('load', this).then(() => fire('loadend', this))
-        return Promise.resolve(data)
+        return data
       }, error => {
         fire('error', this).then(() => fire('loadend', this))
         throw error

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,9 @@ export default class IncludeFragmentElement extends HTMLElement {
 
   load(): Promise<string> {
     observer.unobserve(this)
+    // We mimic the same event order as <img>, including the spec
+    // which states events must be dispatched after "queue a task".
+    // https://www.w3.org/TR/html52/semantics-embedded-content.html#the-img-element
     return task()
       .then(() => {
         this.dispatchEvent(new Event('loadstart'))

--- a/test/test.js
+++ b/test/test.js
@@ -426,36 +426,42 @@ suite('include-fragment-element', function() {
     })
   })
 
-  test('loading events fire in guaranteed order', function() {
-    const elem = document.createElement('include-fragment')
-    const order = []
-    const connected = []
-    const events = [
-      when(elem, 'loadend').then(() => {
-        order.push('loadend')
-        connected.push(elem.isConnected)
-      }),
-      when(elem, 'load').then(() => {
-        order.push('load')
-        connected.push(elem.isConnected)
-      }),
-      when(elem, 'loadstart').then(() => {
-        order.push('loadstart')
-        connected.push(elem.isConnected)
-      })
-    ]
-    elem.src = '/hello'
-
-    // Emulate some kind of timer clamping
+  suite('event order', () => {
     const originalSetTimeout = window.setTimeout
-    let i = 60
-    window.setTimeout = (fn, ms, ...rest) => originalSetTimeout.call(window, fn, ms + (i -= 20), ...rest)
-
-    document.body.appendChild(elem)
-    return Promise.all(events).then(() => {
+    setup(() => {
+      // Emulate some kind of timer clamping
+      let i = 60
+      window.setTimeout = (fn, ms, ...rest) => originalSetTimeout.call(window, fn, ms + (i -= 20), ...rest)
+    })
+    teardown(() => {
       window.setTimeout = originalSetTimeout
-      assert.deepStrictEqual(order, ['loadstart', 'load', 'loadend'])
-      assert.deepStrictEqual(connected, [true, false, false])
+    })
+
+    test('loading events fire in guaranteed order', function() {
+      const elem = document.createElement('include-fragment')
+      const order = []
+      const connected = []
+      const events = [
+        when(elem, 'loadend').then(() => {
+          order.push('loadend')
+          connected.push(elem.isConnected)
+        }),
+        when(elem, 'load').then(() => {
+          order.push('load')
+          connected.push(elem.isConnected)
+        }),
+        when(elem, 'loadstart').then(() => {
+          order.push('loadstart')
+          connected.push(elem.isConnected)
+        })
+      ]
+      elem.src = '/hello'
+      document.body.appendChild(elem)
+
+      return Promise.all(events).then(() => {
+        assert.deepStrictEqual(order, ['loadstart', 'load', 'loadend'])
+        assert.deepStrictEqual(connected, [true, false, false])
+      })
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -426,6 +426,25 @@ suite('include-fragment-element', function() {
     })
   })
 
+  test('loading events fire in guaranteed order', function() {
+    const elem = document.createElement('include-fragment')
+    const order = []
+    const events = [
+      when(elem, 'loadend').then(() => order.push('loadend')),
+      when(elem, 'load').then(() => order.push('load')),
+      when(elem, 'loadstart').then(() => order.push('loadstart'))
+    ]
+    elem.src = '/hello'
+    const originalSetTimeout = window.setTimeout
+    let i = 60
+    window.setTimeout = (fn, ms, ...rest) => originalSetTimeout.call(window, fn, ms + (i -= 20), ...rest)
+    elem.load()
+    return Promise.all(events).then(() => {
+      window.setTimeout = originalSetTimeout
+      assert.deepStrictEqual(order, ['loadstart', 'load', 'loadend'])
+    })
+  })
+
   test('sets loading to "eager" by default', function() {
     const div = document.createElement('div')
     div.innerHTML = '<include-fragment loading="lazy" src="/hello">loading</include-fragment>'


### PR DESCRIPTION
Fixes #21

This refactors `fire` to return a Promise, so that we can determine when an event has been fired (as we're not firing event synchronously).

The test is pretty contrived and implementation dependant, but it red-greens consistently and race condition tests are hard to otherwise verify :shrug: 