### PR TITLE
Fix bug where calling load() on lazy element breaks the loading

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -485,7 +485,6 @@ suite('include-fragment-element', function() {
     const div = document.createElement('div')
     div.innerHTML = '<include-fragment loading="lazy" src="/hello">loading</include-fragment>'
     document.body.appendChild(div)
-    
     return when(div.firstChild, 'include-fragment-replaced').then(() => {
       assert.equal(document.querySelector('include-fragment'), null)
       assert.equal(document.querySelector('#replaced').textContent, 'hello')
@@ -582,9 +581,11 @@ suite('include-fragment-element', function() {
     }, 0)
 
     return load
-      .then(() => when(div.firstChild, 'loadend'))
+      .then(() => when(div.firstChild, 'include-fragment-replaced'))
       .then(() => {
         assert.equal(count, 1, "Load occured too many times")
+        assert.equal(document.querySelector('include-fragment'), null)
+        assert.equal(document.querySelector('#replaced').textContent, 'hello')
       })
   })
 })


### PR DESCRIPTION
_Fixes https://github.com/github/include-fragment-element/issues/67_

This PR fixes https://github.com/github/include-fragment-element/issues/67 where calling `load()` on a `loading=lazy` element causes the contents not to be replaced when the element becomes visible.

## Context

There are two bugs at play here:

1. We were calling `observer.unobserve` when `load()` was called. This is incorrect as it should only be called once content replacement has happened.
2. `load()` doesn't actually properly preload the request, since nothing is done with the response - it should be saved into the weakmap but that is only done by `getData()` not `load()`. 

## Fix

The fix here is twofold:

1. Remove the `observer.unobserve` call from the `load()` code.
2. Move `load()` logic to a private function and instead call `getData` from the `element.load()` function, `getData` correctly caches the response _or_ immediately returns a cached response, so it is the correct code to call to preload the response#66 

## Implications

_Technically_ this change does modify the public api of `include-fragment` - if someone was subclassing the element and re-implementing `load()` to modify say how events are fired, this will no longer work for them. I cannot find any examples of us doing this within github (we do reimplement `fetch` but not `load`.