### PR TITLE
Set host element to a block its Shadow DOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean": "rm -rf dist",
     "lint": "eslint . --ext .js,.ts && tsc --noEmit",
     "prebuild": "npm run clean && npm run lint && mkdir dist",
-    "build": "tsc && cp src/index.css dist/index.css",
+    "build": "tsc",
     "pretest": "npm run build",
     "test": "karma start ./test/karma.config.cjs",
     "prepublishOnly": "npm run build",

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,0 @@
-include-fragment {
-  /* Normalize as a block element across all browsers */
-  display: block;
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,17 @@ export default class IncludeFragmentElement extends HTMLElement {
     }
   }
 
+  constructor() {
+    super()
+    this.attachShadow({mode: 'open'}).innerHTML = `
+      <style> 
+        :host {
+          display: block;
+        }
+      </style>
+      <slot></slot>`
+  }
+
   connectedCallback(): void {
     if (this.src && this.loading === 'eager') {
       handleData(this)


### PR DESCRIPTION
Set the styles of the `<include-fragment>` element in a Shadow DOM instead of a CSS file that needs to be imported with the component.

### 📚  References

https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM