### PR TITLE
Refactor private functions into the component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,10 @@ function task(): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, 0))
 }
 
+function isWildcard(accept: string | null) {
+  return accept && !!accept.split(',').find(x => x.match(/^\s*\*\/\*/))
+}
+
 async function handleData(el: IncludeFragmentElement) {
   observer.unobserve(el)
   return getData(el).then(
@@ -106,10 +110,6 @@ function fetchDataWithEvents(el: IncludeFragmentElement) {
         throw error
       }
     )
-}
-
-function isWildcard(accept: string | null) {
-  return accept && !!accept.split(',').find(x => x.match(/^\s*\*\/\*/))
 }
 
 export default class IncludeFragmentElement extends HTMLElement {


### PR DESCRIPTION
In a future pull request, I want to check the internal state of the component in one of these functions but in order to do that, I'd have to expose the property on the component API. This is undesirable since whenever we want to change the internal functionality we have to make a breaking change release. As the functionality grows this becomes more and more unwieldy.

Instead of doing all that, I want to move these essentially private functions into the component so that we can check the internal state of the component in these functions in the future.