### PR TITLE
Fix the location of `try` in new async code.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -178,19 +178,18 @@ export default class IncludeFragmentElement extends HTMLElement {
     // We mimic the same event order as <img>, including the spec
     // which states events must be dispatched after "queue a task".
     // https://www.w3.org/TR/html52/semantics-embedded-content.html#the-img-element
-
-    await this.#task(['loadstart'])
-    const response = await this.fetch(this.request())
-    if (response.status !== 200) {
-      throw new Error(`Failed to load resource: the server responded with a status of ${response.status}`)
-    }
-    const ct = response.headers.get('Content-Type')
-    if (!isWildcard(this.accept) && (!ct || !ct.includes(this.accept ? this.accept : 'text/html'))) {
-      throw new Error(`Failed to load resource: expected ${this.accept || 'text/html'} but was ${ct}`)
-    }
-    const data = await response.text()
-
     try {
+      await this.#task(['loadstart'])
+      const response = await this.fetch(this.request())
+      if (response.status !== 200) {
+        throw new Error(`Failed to load resource: the server responded with a status of ${response.status}`)
+      }
+      const ct = response.headers.get('Content-Type')
+      if (!isWildcard(this.accept) && (!ct || !ct.includes(this.accept ? this.accept : 'text/html'))) {
+        throw new Error(`Failed to load resource: expected ${this.accept || 'text/html'} but was ${ct}`)
+      }
+      const data = await response.text()
+
       // Dispatch `load` and `loadend` async to allow
       // the `load()` promise to resolve _before_ these
       // events are fired.


### PR DESCRIPTION
I accidentally did not include enough code in the `try` clause in https://github.com/github/include-fragment-element/pull/82 . This PR fixes that.