### PR TITLE
Add a script for `npm run format`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "lint": "eslint . --ext .js,.ts && tsc --noEmit",
+    "format": "eslint --fix . --ext .js,.ts",
     "prebuild": "npm run clean && npm run lint && mkdir dist",
     "build": "tsc",
     "pretest": "npm run build",


### PR DESCRIPTION
I no longer use ESLint personally, so I rely on the commandline for formatting projects like this. A formatting command makes this easier.