### PR TITLE
Refactor content type check for response handling

### DIFF
--- a/src/include-fragment-element.ts
+++ b/src/include-fragment-element.ts
@@ -237,10 +237,6 @@ export class IncludeFragmentElement extends HTMLElement {
       if (response.status !== 200) {
         throw new Error(`Failed to load resource: the server responded with a status of ${response.status}`)
       }
-      const ct = response.headers.get('Content-Type')
-      if (!isWildcard(this.accept) && (!ct || !ct.includes(this.accept ? this.accept : 'text/html'))) {
-        throw new Error(`Failed to load resource: expected ${this.accept || 'text/html'} but was ${ct}`)
-      }
 
       const responseText: string = await response.text()
       let data: string | CSPTrustedHTMLToStringable = responseText
@@ -259,6 +255,10 @@ export class IncludeFragmentElement extends HTMLElement {
       // the `load()` promise to resolve _before_ these
       // events are fired.
       this.#task(['error', 'loadend'], error as Error)
+      const ct = response.headers.get('Content-Type')
+      if (!isWildcard(this.accept) && (!ct || !ct.includes(this.accept ? this.accept : 'text/html'))) {
+        throw new Error(`Failed to load resource: expected ${this.accept || 'text/html'} but was ${ct}`)
+      }
       throw error
     }
   }

--- a/src/include-fragment-element.ts
+++ b/src/include-fragment-element.ts
@@ -234,6 +234,10 @@ export class IncludeFragmentElement extends HTMLElement {
     try {
       await this.#task(['loadstart'])
       const response = await this.fetch(this.request())
+      const ct = response.headers.get('Content-Type')
+      if (!isWildcard(this.accept) && (!ct || !ct.includes(this.accept ? this.accept : 'text/html'))) {
+        throw new Error(`Failed to load resource: expected ${this.accept || 'text/html'} but was ${ct}`)
+      }
       if (response.status !== 200) {
         throw new Error(`Failed to load resource: the server responded with a status of ${response.status}`)
       }
@@ -255,10 +259,6 @@ export class IncludeFragmentElement extends HTMLElement {
       // the `load()` promise to resolve _before_ these
       // events are fired.
       this.#task(['error', 'loadend'], error as Error)
-      const ct = response.headers.get('Content-Type')
-      if (!isWildcard(this.accept) && (!ct || !ct.includes(this.accept ? this.accept : 'text/html'))) {
-        throw new Error(`Failed to load resource: expected ${this.accept || 'text/html'} but was ${ct}`)
-      }
       throw error
     }
   }

--- a/test/test.js
+++ b/test/test.js
@@ -213,7 +213,7 @@ suite('include-fragment-element', function () {
       await el.data
       throw new Error('el.data did not throw')
     } catch (error) {
-      assert.match(error, /the server responded with a status of 406/)
+      assert.match(error, /expected text\/html but was text\/plain/)
     }
   })
 
@@ -343,7 +343,7 @@ suite('include-fragment-element', function () {
     assert.equal(event.bubbles, false)
     assert.equal(event.cancelable, false)
     assert.instanceOf(event.detail.error, Error)
-    assert.equal(event.detail.error.message, 'Failed to load resource: the server responded with a status of 500')
+    assert.equal(event.detail.error.message, 'Failed to load resource: expected text/html but was text/plain;charset=UTF-8')
   })
 
   test('adds is-error class on 500 status', async function () {

--- a/test/test.js
+++ b/test/test.js
@@ -343,7 +343,10 @@ suite('include-fragment-element', function () {
     assert.equal(event.bubbles, false)
     assert.equal(event.cancelable, false)
     assert.instanceOf(event.detail.error, Error)
-    assert.equal(event.detail.error.message, 'Failed to load resource: expected text/html but was text/plain;charset=UTF-8')
+    assert.equal(
+      event.detail.error.message,
+      'Failed to load resource: expected text/html but was text/plain;charset=UTF-8',
+    )
   })
 
   test('adds is-error class on 500 status', async function () {


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/5409

This moves the content type error check to before the `status !== 200` check. The content type one was never getting hit because it was passing `406` as a status code and getting caught by the not 200 check.